### PR TITLE
Update manifest.json to remove repo

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,6 @@
   "id": "searchpp",
   "name": "Search++",
   "version": "0.0.1",
-  "repo": "https://github.com/nhaouari/searchpp",
   "description": "Allow inserting text context search results on the active note, the plugin is based on the plugin mrj-text-expand-witb-text of MrJackphil.",
   "isDesktopOnly": false,
   "author": "Noureddine Haouari",


### PR DESCRIPTION
Hi! I just wanted to let you know that I've been going through older issues over at the [obsidian-hub repo](https://github.com/obsidian-community/obsidian-hub) and noticed that the link to your plugin is broken. :( See: https://github.com/obsidian-community/obsidian-hub/issues/9

I've never written a plugin, so I hope this is correct, but I think the "repo" should not be mentioned in the manifest – the same way you did it for your other plugins as well. That would help us generate the correct URL to this repo.

Thank you!